### PR TITLE
Formatierte Adresse bei qualifizierte Uid Prüfung hinzugefügt

### DIFF
--- a/fields.md
+++ b/fields.md
@@ -234,16 +234,22 @@ verarbeitet werden.
 
 ### Ausgabefelder vatIdCheck
 
-| Feld                       | Erwarteter Wert | Pflicht | Bedeutung                                                                                                                     |
-|----------------------------|-----------------|---------|-------------------------------------------------------------------------------------------------------------------------------|
-| predictions                | Array           | Ja      | Enthält JSON-Objekte mit Korrekturvorschlägen.                                                                                |
-| predictions.vatId          | String          | Ja      | Enthält die formatierte Umsatzsteuer-ID der zu prüfenden Firma.                                                               |
-| predictions.companyName    | String          | Nein    | Enthält den Firmennamen zu diesem Vorschlag.                                                                                  |
-| predictions.companyAddress | String          | Nein    | Enthält die Firmenadresse zu diesem Vorschlag.                                                                                |
-| certification              | JSON            | Nein    | Enthält Informationen zum Zertifikat.                                                                                         |
-| certification.timestamp    | JSON            | Nein    | Enthält den Zeitpunkt der Abfrage.                                                                                            |
-| certification.source       | JSON            | Nein    | Enthält die Datenquelle.                                                                                                      |
-| status                     | Array           | Ja      | Enthält eine Liste aus Statuscodes, die den geprüften Datensatz beschreiben. Siehe [Liste der Statuscodes](./statuscodes.md). |
+| Feld                                               | Erwarteter Wert | Pflicht                                              | Bedeutung                                                                                                                             |
+|----------------------------------------------------|-----------------|------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------|
+| predictions                                        | Array           | Ja                                                   | Enthält JSON-Objekte mit Korrekturvorschlägen.                                                                                        |
+| predictions.vatId                                  | String          | Ja                                                   | Enthält die formatierte Umsatzsteuer-ID der zu prüfenden Firma.                                                                       |
+| predictions.companyName                            | String          | Nein                                                 | Enthält den Firmennamen zu diesem Vorschlag.                                                                                          |
+| predictions.companyAddress                         | String          | Nein                                                 | Enthält die unstrukturierte Firmenadresse zu diesem Vorschlag.                                                                        |
+| predictions.companyAddressFormatted                | String          | Nein                                                 | Enthält die strukturierte Firmenadresse zu diesem Vorschlag. Wird nur zurückgegeben, wenn die Adresse in strukturierter Form vorliegt |
+| predictions.companyAddressFormatted.streetFull     | String          | Ja, wenn die Adresse in strukturierter Form vorliegt | Enthält die Straße ink. Hausnummer der strukturierte Firmenadresse zu diesem Vorschlag.                                               |
+| predictions.companyAddressFormatted.additionalInfo | String          | Ja, wenn die Adresse in strukturierter Form vorliegt | Enthält den Adresszusatz der strukturierte Firmenadresse zu diesem Vorschlag.                                                         |
+| predictions.companyAddressFormatted.postCode       | String          | Ja, wenn die Adresse in strukturierter Form vorliegt | Enthält die Postleitzahl der strukturierte Firmenadresse zu diesem Vorschlag.                                                         |
+| predictions.companyAddressFormatted.cityName       | String          | Ja, wenn die Adresse in strukturierter Form vorliegt | Enthält den Ortsname der strukturierte Firmenadresse zu diesem Vorschlag.                                                             |
+| predictions.companyAddressFormatted.country        | String          | Ja, wenn die Adresse in strukturierter Form vorliegt | Enthält den Ländercode der strukturierte Firmenadresse zu diesem Vorschlag.                                                           |
+| certification                                      | JSON            | Nein                                                 | Enthält Informationen zum Zertifikat.                                                                                                 |
+| certification.timestamp                            | JSON            | Nein                                                 | Enthält den Zeitpunkt der Abfrage.                                                                                                    |
+| certification.source                               | JSON            | Nein                                                 | Enthält die Datenquelle.                                                                                                              |
+| status                                             | Array           | Ja                                                   | Enthält eine Liste aus Statuscodes, die den geprüften Datensatz beschreiben. Siehe [Liste der Statuscodes](./statuscodes.md).         |
 
 ## Weitere Informationen
 

--- a/readme.md
+++ b/readme.md
@@ -1258,3 +1258,74 @@ Siehe [Dokumentation für Feldernamen](./fields.md).
 
 Siehe [Dokumentation für Feldernamen](./fields.md) und [Dokumentation für Status-Codes](./statuscodes.md).
 Siehe [Weitere Beispiele](./vatid-check-examples.md).
+
+*Beispiel 2: Qualifizierte Validierung einer Umsatzsteuer-ID.*
+```
+POST https://endereco-service.de/rpc/v1
+```
+
+#### Request Headers
+
+|  |  |
+|---|---|
+| Content-Type| application/json  |
+| X-Transaction-Id | not_required, siehe [Generierung der Session ID's](./sessions-guideline.md) |
+| X-Agent | MyClient v1.0.0, siehe [Client ID Guideline](./client-id-guideline.md) |
+| X-Transaction-Referer | www.example.de/register, siehe [Referrer übergeben](./providing-referrer.md) |
+| X-Auth-Key | siehe [Authentifizierung](#authentifizierung) |
+
+#### Body raw (JSON)
+
+```json
+{
+   "jsonrpc": "2.0",
+   "id": 1,
+   "method": "vatIdCheck",
+   "params": {
+      "vatId": "DE297464149",
+      "requesterVatID": "DE297464149",
+      "companyName": "endereco",
+      "companyPostalCode": "97236",
+      "companyLocality": "Randersacker",
+      "companyStreetFull": "Balthasar-Neumann Str. 4b"
+   }
+}
+```
+
+Siehe [Dokumentation für Feldernamen](./fields.md).
+
+#### Antwort Basis
+
+```json
+{
+   "jsonrpc": "2.0",
+   "id": 1,
+   "result": {
+      "predictions": [
+         {
+            "vatId": "DE297464149",
+            "companyName": "endereco UG (haftungsbeschränkt) Gesellschaft für Master Data Quality Management",
+            "companyAddress": "Balthasar-Neumann Str. 4b, 97236, Randersacker",
+            "companyAddressFormatted": {
+               "streetFull": "Balthasar-Neumann Str. 4b",
+               "additionalInfo": "",
+               "postCode": "97236",
+               "cityName": "Randersacker",
+               "country": "DE"
+            }
+         }
+      ],
+      "cerification": {
+         "timestamp": "2023-10-26 07:24:26",
+         "source": "api.vat-search.eu"
+      },
+      "status": [
+         "vat_id_valid",
+         "vat_id_format_correct"
+      ]
+   }
+}
+```
+
+Siehe [Dokumentation für Feldernamen](./fields.md) und [Dokumentation für Status-Codes](./statuscodes.md).
+Siehe [Weitere Beispiele](./vatid-check-examples.md).

--- a/vatid-check-examples.md
+++ b/vatid-check-examples.md
@@ -136,11 +136,18 @@ Siehe auch:
             {
                 "vatId": "DE297464149",
                 "companyName": "endereco UG (haftungsbeschränkt) Gesellschaft für Master Data Quality Management",
-                "companyAddress": "Balthasar-Neumann Str. 4b, 97236, Randersacker"
+                "companyAddress": "Balthasar-Neumann Str. 4b, 97236, Randersacker",
+                "companyAddressFormatted": {
+                    "streetFull": "Balthasar-Neumann Str. 4b",
+                    "additionalInfo": "",
+                    "postCode": "97236",
+                    "cityName": "Randersacker",
+                    "country": "DE"
+                }
             }
         ],
         "cerification": {
-            "timestamp": "2023-06-15 11:09:56",
+            "timestamp": "2023-10-26 07:24:26",
             "source": "api.vat-search.eu"
         },
         "status": [
@@ -222,11 +229,18 @@ Siehe auch:
             {
                 "vatId": "DE297464149",
                 "companyName": "endereco UG (haftungsbeschränkt) Gesellschaft für Master Data Quality Management",
-                "companyAddress": "Balthasar-Neumann Str. 4b, 97236, Randersacker"
+                "companyAddress": "Balthasar-Neumann Str. 4b, 97236, Randersacker",
+                "companyAddressFormatted": {
+                    "streetFull": "Balthasar-Neumann Str. 4b",
+                    "additionalInfo": "",
+                    "postCode": "97236",
+                    "cityName": "Randersacker",
+                    "country": "DE"
+                }
             }
         ],
         "cerification": {
-            "timestamp": "2023-06-15 11:11:13",
+            "timestamp": "2023-10-26 07:40:30",
             "source": "api.vat-search.eu"
         },
         "status": [


### PR DESCRIPTION
Da die Ausgabe der qualifizierten Uid Prüfung angepasst wurde, wurde die Dokumentation überarbeitet.

Es wurde auf der Hauptseite ein Beispiel für die qualifizierte Uid Prüfung hinzugefügt Es wurden die Beschreibung der Ausgabefelder erweitert Es wurde die formatierte Adresse bei den Beispielen hinzugefügt

EIN-596